### PR TITLE
(wip) [chore] only allow users to grab their own profile unless Employee and above

### DIFF
--- a/snakebite/middlewares/auth.py
+++ b/snakebite/middlewares/auth.py
@@ -31,7 +31,7 @@ ACL_MAP = {
         'post': Role.EMPLOYEE,
     },
     '/users/+': {
-        'get': Role.EMPLOYEE,
+        'get': Role.USER,
         'put': Role.EMPLOYEE,
         'delete': Role.EMPLOYEE
     },
@@ -104,5 +104,5 @@ class JWTAuthMiddleware(object):
             )
 
         # user is authorized!
-        # set user ID in request header
-        req.headers[constants.AUTH_HEADER_USER_ID] = user_id
+        # set user ID in request params
+        req.params[constants.AUTH_HEADER_USER_ID] = user_id


### PR DESCRIPTION
This PR updates the User endpoints such that:
- unless request user is of Employee role and above, s/he can only access his/own user profile with the `GET /users/{id}` endpoint
- after token validation, the request user's ID is saved in request params instead of headers (for easy access in endpoint handlers)
#### todo
- [x] check that request user role and only allow user to request own profile unless Employee and above
